### PR TITLE
when destructor, the WebSocket will invoke WebSocket::Delegate's onClose...

### DIFF
--- a/quick/lib/lua_bindings/manual/Lua_web_socket.h
+++ b/quick/lib/lua_bindings/manual/Lua_web_socket.h
@@ -35,7 +35,7 @@ extern "C" {
 #endif
 
 #include "network/WebSocket.h"
-class LuaWebSocket: public cocos2d::network::WebSocket,public cocos2d::network::WebSocket::Delegate
+class LuaWebSocket: public cocos2d::network::WebSocket::Delegate, public cocos2d::network::WebSocket
 {
 public:
     virtual ~LuaWebSocket();


### PR DESCRIPTION
基类WebSocket在析构函数中会调用WebSocket::Delegate::onClose，
在以前的写法下，
第二基类WebSocket::Delegate先于第一基类WebSocket析构，导致非法访问。
