### PR TITLE
Fix touch bug: 多点触摸时, onTouchesCancelled发生后, 由于触摸点数据就没有清空, 导致在后续的事件中onTo...

### DIFF
--- a/external/lua/quick/LuaTouchEventManager.cpp
+++ b/external/lua/quick/LuaTouchEventManager.cpp
@@ -320,6 +320,8 @@ void LuaTouchEventManager::onTouchesCancelled(const std::vector<Touch*>& touches
     // remove all touching nodes
     //CCLOG("TOUCH CANCELLED, REMOVE ALL TOUCH TARGETS");
     _touchingTargets.clear();
+    // clear all touching points
+	m_touchingIds.clear();
 }
 
 void LuaTouchEventManager::cleanup(void)


### PR DESCRIPTION
Fix touch bug: 多点触摸时, onTouchesCancelled发生后, 由于触摸点数据就没有清空, 导致在后续的事件中onTo...uchesEnded判断只发送removed事件, 而实际上在cancelled时应该认为ended已发生, 所以清空
