### PR TITLE
bugfix: use iterator and earse in loop lead to crash

### DIFF
--- a/external/lua/quick/LuaTouchEventManager.cpp
+++ b/external/lua/quick/LuaTouchEventManager.cpp
@@ -163,9 +163,9 @@ void LuaTouchEventManager::onTouchesBegan(const std::vector<Touch*>& touches, Ev
     LuaEventNode *checkTouchableNode = nullptr;
     LuaTouchTargetNode *touchTarget = nullptr;
 
-    for (auto iter = _touchableNodes.begin(); iter != _touchableNodes.end(); ++iter)
+	for (std::size_t i = 0; i < _touchableNodes.size(); ++i)
     {
-        checkTouchableNode = node = *iter;
+		checkTouchableNode = node = _touchableNodes.at(i);
 
         // check node is visible and capturing enabled
         isTouchable = true;


### PR DESCRIPTION
cause:
        in this loop , use a std::vector<T>::iterator for traverse a std::vector<T>, but in the loop body after 10 level funtion calls, this vector use a std::vector<T>::erase lead to this iterator be invalid。

Behavior:
        on *nix platform, becaus std implement, it just skip a vector element, (lossing a T element ), on Windows, it crashes but nothing

fix:
        there is no need to use iterator, we can modify it to use std::vector<T>::at(i)
