### PR TITLE
fix memory leak in UIListView

### DIFF
--- a/quick/framework/cc/ui/UIListView.lua
+++ b/quick/framework/cc/ui/UIListView.lua
@@ -111,6 +111,8 @@ function UIListView:ctor(params)
 	self.redundancyViewVal = 0 --异步的视图两个方向上的冗余大小,横向代表宽,竖向代表高
 
 	self.args_ = {params}
+
+    self:setNodeEventEnabled(true)
 end
 
 function UIListView:onCleanup()


### PR DESCRIPTION
Without setting `setNodeEventEnabled` as true for a UIListView, the items in its `itemsFree_` will not be released since `UIListView:onCleanup` will not be called, which cause memory leak.
